### PR TITLE
allow 'highlights' path prefixes for use with CloudFront

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+/config/secrets.yml
+
+.env
+
 coverage/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'dotenv-rails'
 
 gem "openstax_swagger", github: 'openstax/swagger-rails', ref: '0ad77d306d2'
 
+# Allow requests with a 'highlights' prefix to support use via CloudFront
+gem "openstax_path_prefixer", github: 'openstax/path_prefixer', ref: '0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd'
+
 group :test do
   # Code Climate integration
   # gem "codeclimate-test-reporter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/openstax/path_prefixer.git
+  revision: 0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd
+  ref: 0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd
+  specs:
+    openstax_path_prefixer (0.0.1)
+      rails (>= 3.0)
+
+GIT
   remote: https://github.com/openstax/swagger-rails.git
   revision: 0ad77d306d24e220fb4703f4a9f02e219493bc02
   ref: 0ad77d306d2
@@ -233,6 +241,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   openstax_healthcheck
+  openstax_path_prefixer!
   openstax_swagger!
   pg (>= 0.18, < 2.0)
   pry-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,9 @@ require "rails"
 # This is the railtie middleware stack.
 # !! Have removed some of these to improve API performance. !!
 require "active_model/railtie"
-# require "active_job/railtie"
+# can comment out active_job/railtie after next 5.2.x release, see
+# https://github.com/rails/rails/pull/35896#issuecomment-535569136
+require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"

--- a/config/initializers/openstax_path_prefixer.rb
+++ b/config/initializers/openstax_path_prefixer.rb
@@ -1,0 +1,4 @@
+OpenStax::PathPrefixer.configure do |config|
+  config.prefix_assets = false
+  config.prefix = "highlights"
+end

--- a/spec/requests/path_prefixer_spec.rb
+++ b/spec/requests/path_prefixer_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe '"highlights" path prefix', type: :request do
+
+  it "should route requests that have the prefix" do
+    expect_any_instance_of(Api::V0::InfoController).to receive(:info)
+    get("/highlights/api/v0/info")
+  end
+
+  it "should route requests that don't have the prefix" do
+    expect_any_instance_of(Api::V0::InfoController).to receive(:info)
+    get("/api/v0/info")
+  end
+
+end


### PR DESCRIPTION
allow 'highlights' path prefixes for use with CloudFront