### PR TITLE
Open CORS for swagger endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem 'sentry-raven'
 # Profiling
 gem 'scout_apm', '~> 3.0.x'
 
+# CORS
+gem 'rack-cors'
+
 group :test do
   # Code Climate integration
   # gem "codeclimate-test-reporter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     psych (3.1.0)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cors (1.1.0)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -268,6 +270,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   rspec-json_expectations
   rspec-rails (~> 3.8)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,14 @@ Bundler.require(*Rails.groups)
 
 module HighlightsApi
   class Application < Rails::Application
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/api/v\d+/swagger', headers: :any, methods: [:get]
+      end
+    end
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 


### PR DESCRIPTION
Will let us show the Swagger UI from a non OpenStax.org site.  Tested with curl.

works for swagger endpoint:

```
[15:19:09] jps: curl -H "Origin:*" -I http://localhost:4004/api/v0/swagger
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET
Access-Control-Expose-Headers: 
Access-Control-Max-Age: 7200
Content-Type: application/json; charset=utf-8
ETag: W/"5828084c909c5447691fe43961b5b195"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: 652a8e61-028b-4f9d-8eaa-cc75a02fb271
X-Runtime: 0.095042
Vary: Origin
```

but not for other endpoints:

```
[15:21:02] jps: curl -H "Origin:*" -I http://localhost:4004/api/v0/info
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
ETag: W/"94f6f0e9eb3f834ebd63a6ba059d769d"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: c7a4d36d-fd3d-4c05-8e2b-999144a0ecee
X-Runtime: 0.014851
```