### PR TITLE
Change swagger to generate x[]=entry1&x[]=entry2 source_ids in query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage/*
 
 .DS_Store
 
+clients/*

--- a/app/bindings/api/v0/bindings/highlight.rb
+++ b/app/bindings/api/v0/bindings/highlight.rb
@@ -44,7 +44,7 @@ module Api::V0::Bindings
     # The note attached to the highlight.
     attr_accessor :annotation
 
-    # Location strategies for the highlight. Items should have a schema matching the strategy schemas that have been defined.
+    # Location strategies for the highlight. Items should have a schema matching the strategy schemas that have been defined. (`XpathRangeSelector` or `TextPositionSelector`).
     attr_accessor :location_strategies
 
     # A number whose relative value gives the highlight's order within the source. Its value has no meaning on its own.

--- a/app/bindings/api/v0/bindings/new_highlight.rb
+++ b/app/bindings/api/v0/bindings/new_highlight.rb
@@ -44,7 +44,7 @@ module Api::V0::Bindings
     # The note attached to the highlight.
     attr_accessor :annotation
 
-    # Location strategies for the highlight. Items should have a schema matching the strategy schemas that have been defined.
+    # Location strategies for the highlight. Items should have a schema matching the strategy schemas that have been defined. (`XpathRangeSelector` or `TextPositionSelector`).
     attr_accessor :location_strategies
 
     class EnumAttributeValidator

--- a/app/controllers/api/v0/highlights_controller.rb
+++ b/app/controllers/api/v0/highlights_controller.rb
@@ -16,7 +16,7 @@ class Api::V0::HighlightsController < Api::V0::BaseController
   end
 
   def index
-    inbound_binding, error = bind(query_parameters, Api::V0::Bindings::GetHighlightsParameters)
+    inbound_binding, error = bind(request.query_parameters, Api::V0::Bindings::GetHighlightsParameters)
     render(json: error, status: error.status_code) and return if error
 
     query_result = inbound_binding.query(user_uuid: current_user_uuid)
@@ -45,15 +45,6 @@ class Api::V0::HighlightsController < Api::V0::BaseController
   def get_highlight
     @highlight = Highlight.find(params[:id])
     raise SecurityTransgression unless @highlight.user_uuid == current_user_uuid
-  end
-
-  def query_parameters
-    request.query_parameters.tap do |parameters|
-      # Some clients (including swagger-codegen clients) submit source IDs as a comma separate
-      # string; our bindings don't know to split them into an array, so split them ahead of
-      # time here.
-      parameters["source_ids"] = parameters["source_ids"].split(',') if parameters["source_ids"].is_a?(String)
-    end
   end
 
 end

--- a/app/controllers/api/v0/highlights_controller.rb
+++ b/app/controllers/api/v0/highlights_controller.rb
@@ -16,7 +16,7 @@ class Api::V0::HighlightsController < Api::V0::BaseController
   end
 
   def index
-    inbound_binding, error = bind(request.query_parameters, Api::V0::Bindings::GetHighlightsParameters)
+    inbound_binding, error = bind(query_parameters, Api::V0::Bindings::GetHighlightsParameters)
     render(json: error, status: error.status_code) and return if error
 
     query_result = inbound_binding.query(user_uuid: current_user_uuid)
@@ -45,6 +45,15 @@ class Api::V0::HighlightsController < Api::V0::BaseController
   def get_highlight
     @highlight = Highlight.find(params[:id])
     raise SecurityTransgression unless @highlight.user_uuid == current_user_uuid
+  end
+
+  def query_parameters
+    request.query_parameters.tap do |parameters|
+      # Some clients (including swagger-codegen clients) submit source IDs as a comma separate
+      # string; our bindings don't know to split them into an array, so split them ahead of
+      # time here.
+      parameters["source_ids"] = parameters["source_ids"].split(',') if parameters["source_ids"].is_a?(String)
+    end
   end
 
 end

--- a/app/controllers/api/v0/highlights_swagger.rb
+++ b/app/controllers/api/v0/highlights_swagger.rb
@@ -243,6 +243,7 @@ class Api::V0::HighlightsSwagger
         key :name, :source_ids
         key :in, :query
         key :type, :array
+        key :collectionFormat, :multi
         key :required, false
         key :description, 'One or more source IDs; query results will contain highlights ordered '\
                           'by the order of these source IDs and ordered within each source.  If ' \

--- a/config/initializers/openstax_swagger.rb
+++ b/config/initializers/openstax_swagger.rb
@@ -4,4 +4,15 @@ OpenStax::Swagger.configure do |config|
       "Api::V#{api_major_version}::SwaggerController::SWAGGERED_CLASSES".constantize
     )
   }
+  config.client_language_configs = {
+    ruby: lambda do |version|
+      {
+        gemName: 'highlights-ruby',
+        gemHomepage: 'https://github.com/openstax/highlights-api/clients/ruby',
+        gemRequiredRubyVersion: '>= 2.4',
+        moduleName: "OpenStax::Highlights",
+        gemVersion: version,
+      }
+    end
+  }
 end

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
           end
         end
 
+        context 'source IDs passed as a comma-separated list in the query parameters' do
+          it 'handles them fine' do
+            get "/api/v0/highlights?source_type=openstax_page&scope_id=#{scope_1_id}&" \
+                "source_ids=#{highlight3.source_id},#{highlight2.source_id},#{highlight1.source_id}"
+            expect(response).to have_http_status(:ok)
+            expect(highlights.map{|hl| hl[:id]}).to eq(
+              [highlight3, highlight2, highlight1, highlight5, highlight4].map(&:id)
+            )
+          end
+        end
+
         context 'with paging' do
           it('gets the user\'s highlights in the order of the source IDs and then by order within page and paginates') do
             test_cases = [
@@ -117,6 +128,8 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
             end
           end
         end
+
+
       end
 
       context 'when only the scope is provided' do

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
           end
         end
 
-        context 'source IDs passed as a comma-separated list in the query parameters' do
+        context 'source IDs passed as source_ids[]=entry1&source_ids[]=entry2 in the query parameters' do
           it 'handles them fine' do
             get "/api/v0/highlights?source_type=openstax_page&scope_id=#{scope_1_id}&" \
-                "source_ids=#{highlight3.source_id},#{highlight2.source_id},#{highlight1.source_id}"
+                "source_ids[]=#{highlight3.source_id}&source_ids[]=#{highlight2.source_id}&source_ids[]=#{highlight1.source_id}"
             expect(response).to have_http_status(:ok)
             expect(highlights.map{|hl| hl[:id]}).to eq(
               [highlight3, highlight2, highlight1, highlight5, highlight4].map(&:id)
@@ -128,8 +128,6 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
             end
           end
         end
-
-
       end
 
       context 'when only the scope is provided' do


### PR DESCRIPTION
Change swagger to generate x[]=entry1&x[]=entry2 source_ids in query parameters instead of a comma-separated list (the BE wasn't handling the comma separated list well)