### PR TITLE
move service limit exception handler to make it catch

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -2,10 +2,6 @@ class Api::V0::BaseController < ApplicationController
   include Swagger::Blocks
   include OpenStax::Swagger::Bind
 
-  rescue_from_unless_local ServiceLimits::ServiceLimitsError, send_to_sentry: true do |ex|
-    render json: binding_error(status_code: 403, messages: [ex.message]), status: 403
-  end
-
   rescue_from_unless_local StandardError, send_to_sentry: true do |ex|
     render json: binding_error(status_code: 500, messages: [ex.message]), status: 500
   end
@@ -20,6 +16,10 @@ class Api::V0::BaseController < ApplicationController
 
   rescue_from_unless_local SecurityTransgression do |ex|
     head :forbidden
+  end
+
+  rescue_from_unless_local ServiceLimits::ServiceLimitsError, send_to_sentry: true do |ex|
+    render json: binding_error(status_code: 403, messages: [ex.message]), status: 403
   end
 
   protected

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -309,6 +309,14 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
               .to match(/invalid strategy detected/)
           end
         end
+
+        context 'when the highlight annotation is too long' do
+          it '403s' do
+            valid_inner_attributes[:annotation] = "a" * (ServiceLimits::MAX_CHARS_PER_ANNOTATION + 1)
+            post highlights_path, params: valid_attributes
+            expect(response).to have_http_status(403)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
`ServiceLimitsError` was in the wrong order for it to catch, so those errors were getting handled as `StandardError` which gave 500s.

cc @steveburkett 