### PR TITLE
Load testing configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,16 @@
 require 'openstax/auth/strategy_1'
 
 class ApplicationController < ActionController::API
-
   protected
 
   include RescueFromUnlessLocal
 
   def current_user_uuid
     @current_user_uuid ||= begin
+      if Rails.application.secrets[:loadtesting_active] == 'true' && request.headers['HTTP_LOADTEST_CLIENT_UUID']
+        return request.headers['HTTP_LOADTEST_CLIENT_UUID']
+      end
+
       if Rails.env.development? && ENV['STUBBED_USER_UUID']
         ENV['STUBBED_USER_UUID']
       else
@@ -24,5 +27,4 @@ class ApplicationController < ActionController::API
   def render_unauthorized_if_no_current_user
     head :unauthorized if current_user_uuid.nil?
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::API
 
   def current_user_uuid
     @current_user_uuid ||= begin
-      if Rails.application.secrets[:loadtesting_active] == 'true' && request.headers['HTTP_LOADTEST_CLIENT_UUID']
+      if Rails.application.load_testing? && request.headers['HTTP_LOADTEST_CLIENT_UUID']
         return request.headers['HTTP_LOADTEST_CLIENT_UUID']
       end
 

--- a/app/services/service_limits.rb
+++ b/app/services/service_limits.rb
@@ -2,10 +2,10 @@
 #
 # This class is the guard check for the HighlightsController CRUD actions
 class ServiceLimits
-  MAX_HIGHLIGHTS_PER_SOURCE_PER_USER = 300
-  MAX_HIGHLIGHTS_PER_USER            = 20_000
-  MAX_ANNOTATION_CHARS_PER_USER      = 300_000
-  MAX_CHARS_PER_ANNOTATION           = 1_000
+  MAX_HIGHLIGHTS_PER_SOURCE_PER_USER = 300_000_000
+  MAX_HIGHLIGHTS_PER_USER            = 20_000_000_000
+  MAX_ANNOTATION_CHARS_PER_USER      = 300_000_000_000
+  MAX_CHARS_PER_ANNOTATION           = 1_000_000_000
 
   class ServiceLimitsError < StandardError; end
 

--- a/app/services/service_limits.rb
+++ b/app/services/service_limits.rb
@@ -2,10 +2,11 @@
 #
 # This class is the guard check for the HighlightsController CRUD actions
 class ServiceLimits
-  MAX_HIGHLIGHTS_PER_SOURCE_PER_USER = 300_000_000
-  MAX_HIGHLIGHTS_PER_USER            = 20_000_000_000
-  MAX_ANNOTATION_CHARS_PER_USER      = 300_000_000_000
-  MAX_CHARS_PER_ANNOTATION           = 1_000_000_000
+  # Use way huge limits in load testing so we still do the checks but do not hit limits
+  MAX_HIGHLIGHTS_PER_SOURCE_PER_USER = !Rails.application.load_testing? ? 300      : 300_000_000
+  MAX_HIGHLIGHTS_PER_USER            = !Rails.application.load_testing? ? 20_000   : 20_000_000_000
+  MAX_ANNOTATION_CHARS_PER_USER      = !Rails.application.load_testing? ? 300_000  : 300_000_000_000
+  MAX_CHARS_PER_ANNOTATION           = !Rails.application.load_testing? ? 1_000    : 1_000_000_000
 
   class ServiceLimitsError < StandardError; end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,10 @@ module HighlightsApi
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
+
+    def load_testing?
+      Rails.application.secrets[:loadtesting_active] == 'true'
+    end
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,9 @@
 if Rails.env.development?
   Highlight.destroy_all
 
-  hl = Highlight.create!(user_id: '52f42df8-17f4-4ad2-a702-3d6b8174a4df',
+  user = User.create(id: '52f42df8-17f4-4ad2-a702-3d6b8174a4df')
+
+  hl = Highlight.create!(user_id: user.id,
                          source_type: 'openstax_page',
                          color: 'yellow',
                          source_id: 'daece11d-23a1-4f2f-b184-d9bc6ef7849d',
@@ -13,7 +15,7 @@ if Rails.env.development?
                                                  "type": 'TextPositionSelector',
                                                  "start": '12' }])
 
-  hl = Highlight.create!(user_id: '52f42df8-17f4-4ad2-a702-3d6b8174a4df',
+  hl = Highlight.create!(user_id: user.id,
                          source_type: 'openstax_page',
                          color: 'yellow',
                          source_id: 'daece11d-23a1-4f2f-b184-d9bc6ef7849d',
@@ -26,7 +28,7 @@ if Rails.env.development?
                                                  "type": 'TextPositionSelector',
                                                  "start": '12' }])
 
-  Highlight.create!(user_id: '52f42df8-17f4-4ad2-a702-3d6b8174a4df',
+  Highlight.create!(user_id: user.id,
                     source_type: 'openstax_page',
                     color: 'green',
                     prev_highlight_id: hl.id,
@@ -39,7 +41,7 @@ if Rails.env.development?
                                             "type": 'TextPositionSelector',
                                             "start": '22' }])
 
-  Highlight.create!(user_id: 'c967ccb8-97ad-4031-9fe5-7df8af056bfb',
+  Highlight.create!(user_id: user.id,
                     source_type: 'openstax_page',
                     color: 'pink',
                     source_id: 'e0ebcd05-0fbf-4fc2-a063-9c68d424fc5c',

--- a/lib/tasks/install_secrets.rake
+++ b/lib/tasks/install_secrets.rake
@@ -70,6 +70,8 @@ task :install_secrets, [] do
     }
   })
 
+  secrets[:loadtesting_active] = (/loadtesting/.match?(env_name)).to_s
+
   write_yaml_file("config/secrets.yml", {
     production: secrets
   })


### PR DESCRIPTION
* Allow stubbed user IDs in load testing environments
* Set sky high service limits during load testing
* Make load testing configuration only happen when `loadtesting` is in the env name