### PR TITLE
Improve the memory "hit" when source_ids are not given

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "aws-sdk-ssm"
 
 gem 'dotenv-rails'
 
-gem 'will_paginate', '~> 3.1.7', require: false
+gem 'will_paginate', '~> 3.1.7'
 
 gem "openstax_swagger", github: 'openstax/swagger-rails', ref: '9bff4962b31e142debbc62390f1fd3adab3af055'
 

--- a/config/initializers/highlight_override.rb
+++ b/config/initializers/highlight_override.rb
@@ -89,10 +89,11 @@ Api::V0::Bindings::GetHighlightsParameters.class_exec do
       highlights = highlights.public_send("by_#{key}", value) if value.present?
     end
 
-    highlights = highlights.to_a
 
     if source_ids.present?
       # Sort the highlights in Ruby, not Postgres
+      highlights = highlights.to_a
+
       source_id_order = source_ids.each_with_object({}).with_index do |(source_id, hash), index|
         hash[source_id] = index
       end
@@ -100,7 +101,7 @@ Api::V0::Bindings::GetHighlightsParameters.class_exec do
       highlights.sort_by!{ |highlight| [source_id_order[highlight.source_id], highlight.order_in_source] }
     else
       # Have to sort by something for pagination to be sensible, choose created_at
-      highlights.sort_by!(&:created_at)
+      highlights.order(created_at: :desc)
     end
 
     highlights.paginate(


### PR DESCRIPTION
We found during load testing that indexing w/out source IDs, can cause a memory burden on the rails app because so many highlights are loaded into memory before sorting.  this will use the order to order in postgres and apply pagination to the results. 