### PR TITLE
simplify routing errors in logs

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -22,6 +22,10 @@ class Api::V0::BaseController < ApplicationController
     render json: binding_error(status_code: 403, messages: [ex.message]), status: 403
   end
 
+  def error_404
+    render json: "Bad Request", status: 404
+  end
+
   protected
 
   def validate_current_user_authorized_as_admin

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -22,10 +22,6 @@ class Api::V0::BaseController < ApplicationController
     render json: binding_error(status_code: 403, messages: [ex.message]), status: 403
   end
 
-  def error_404
-    render json: "Bad Request", status: 404
-  end
-
   protected
 
   def validate_current_user_authorized_as_admin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 require 'openstax/auth/strategy_1'
 
 class ApplicationController < ActionController::API
+  def error_404
+    render json: "Bad Request", status: 404
+  end
+
   protected
 
   include RescueFromUnlessLocal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  match '*path', via: :all, to: 'api/v0/base#error_404'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
     end
   end
 
-  match '*path', via: :all, to: 'api/v0/base#error_404'
+  match '*path', via: :all, to: 'application#error_404'
 end

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
 
   before { allow(Rails.application.config).to receive(:consider_all_requests_local) { false } }
 
+  describe 'GET /highlights/foobar' do
+    context 'bogus url' do
+      it 'handles as a bad request' do
+        get highlights_path(id: 1)
+        expect(response.status).to eq 404
+        expect(response.body).to eq 'Bad Request'
+      end
+    end
+  end
+
   describe 'GET /highlights' do
     let!(:highlight1) { create(:highlight, id: fake_uuid(1), user_id: user_id, source_id: source_id, scope_id: scope_1_id, color: "pink") }
     let!(:highlight2) { create(:highlight, id: fake_uuid(2), user_id: user_id,                       scope_id: scope_1_id, color: "green") }


### PR DESCRIPTION
404s/routing errors unnecessarily clog up the log files. 

This handles routing errors w/ a concise one liner (the normal Get log w/ status) and returns "bad request"

![image](https://user-images.githubusercontent.com/352161/71112781-1ed51400-2181-11ea-915e-ce1c80379a28.png)

https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/742