### PR TITLE
Add advisory locks to highlights

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'scout_apm', '~> 3.0.x'
 # CORS
 gem 'rack-cors'
 
+gem 'with_advisory_lock'
+
 group :test do
   # Code Climate integration
   # gem "codeclimate-test-reporter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     will_paginate (3.1.8)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     yard (0.9.20)
 
 PLATFORMS
@@ -289,6 +291,7 @@ DEPENDENCIES
   tzinfo-data
   versionist
   will_paginate (~> 3.1.7)
+  with_advisory_lock
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/controllers/api/v0/highlights_controller.rb
+++ b/app/controllers/api/v0/highlights_controller.rb
@@ -10,12 +10,15 @@ class Api::V0::HighlightsController < Api::V0::BaseController
     inbound_binding, error = bind(params.require(:highlight), Api::V0::Bindings::NewHighlight)
     render(json: error, status: error.status_code) and return if error
 
-    created_highlight = service_limits.with_create_protection do |user|
-      inbound_binding.create_model!(user_id: user.id)
+    user_id = params[:highlight][:user_id]
+    source_id = params[:highlight][:source_id]
+    Highlight.with_advisory_lock("#{user_id}#{source_id}") do
+      created_highlight = service_limits.with_create_protection do |user|
+        inbound_binding.create_model!(user_id: user.id)
+      end
+      response_binding = Api::V0::Bindings::Highlight.create_from_model(created_highlight)
+      render json: response_binding, status: :created
     end
-
-    response_binding = Api::V0::Bindings::Highlight.create_from_model(created_highlight)
-    render json: response_binding, status: :created
   end
 
   def index
@@ -43,20 +46,25 @@ class Api::V0::HighlightsController < Api::V0::BaseController
     inbound_binding, error = bind(params.require(:highlight), Api::V0::Bindings::HighlightUpdate)
     render(json: error, status: error.status_code) and return if error
 
-    updated_highlight = service_limits.with_update_protection do
-      inbound_binding.update_model!(@highlight)
+    highlight = Highlight.find(params[:id]) #refetch the highlight inside of the advisory lock
+    service_limits.with_update_protection do
+      inbound_binding.update_model!(highlight)
     end
-
     response_binding = Api::V0::Bindings::Highlight.create_from_model(updated_highlight)
     render json: response_binding, status: :ok
   end
+end
 
   def destroy
-    service_limits.with_delete_tracking do
-      @highlight.destroy!
+    user_id = @highlight.user_id
+    source_id = @highlight.source_id
+    Highlight.with_advisory_lock("#{user_id}#{source_id}") do
+      highlight = Highlight.find(params[:id]) #refetch the highlight inside of the advisory lock
+      service_limits.with_delete_tracking do
+        highlight.destroy!
+      end
+      head :ok
     end
-
-    head :ok
   end
 
   private

--- a/app/controllers/api/v0/highlights_controller.rb
+++ b/app/controllers/api/v0/highlights_controller.rb
@@ -10,15 +10,17 @@ class Api::V0::HighlightsController < Api::V0::BaseController
     inbound_binding, error = bind(params.require(:highlight), Api::V0::Bindings::NewHighlight)
     render(json: error, status: error.status_code) and return if error
 
-    user_id = params[:highlight][:user_id]
     source_id = params[:highlight][:source_id]
-    Highlight.with_advisory_lock("#{user_id}#{source_id}") do
+    Rails.logger.error("Before advisory lock for create for '#{current_user_uuid}-#{source_id}'")
+    Highlight.with_advisory_lock("#{current_user_uuid}#{source_id}") do
+      Rails.logger.error("Inside advisory lock for create for '#{current_user_uuid}-#{source_id}'")
       created_highlight = service_limits.with_create_protection do |user|
         inbound_binding.create_model!(user_id: user.id)
       end
       response_binding = Api::V0::Bindings::Highlight.create_from_model(created_highlight)
       render json: response_binding, status: :created
     end
+    Rails.logger.error("After advisory lock for create for '#{current_user_uuid}-#{source_id}'")
   end
 
   def index
@@ -53,18 +55,20 @@ class Api::V0::HighlightsController < Api::V0::BaseController
     response_binding = Api::V0::Bindings::Highlight.create_from_model(updated_highlight)
     render json: response_binding, status: :ok
   end
-end
 
   def destroy
-    user_id = @highlight.user_id
     source_id = @highlight.source_id
-    Highlight.with_advisory_lock("#{user_id}#{source_id}") do
+    Rails.logger.error("Before advisory lock for delete for user: #{current_user_uuid} source: #{source_id} hl: #{@highlight.id}")
+    Highlight.with_advisory_lock("#{current_user_uuid}#{source_id}") do
+      Rails.logger.error("Entered into advisory lock for delete for '#{current_user_uuid}-#{source_id}'")
       highlight = Highlight.find(params[:id]) #refetch the highlight inside of the advisory lock
       service_limits.with_delete_tracking do
+        Rails.logger.error("Inside and deleting! advisory lock for user: #{current_user_uuid} source: #{source_id} hl: #{@highlight.id}")
         highlight.destroy!
       end
       head :ok
     end
+    Rails.logger.error("After advisory lock for delete for user: #{current_user_uuid} source: #{source_id} hl: #{@highlight.id}")
   end
 
   private
@@ -87,5 +91,4 @@ end
       parameters["colors"] = parameters["colors"].split(',') if parameters["colors"].is_a?(String)
     end
   end
-
 end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -140,6 +140,12 @@ class Highlight < ApplicationRecord
   end
 
   def reconnect_neighbors_around_destroyed_highlight
+    if prev_highlight
+      Rails.logger.error("before_delete hook- inside advisory lock for, updating hl: #{prev_highlight.id} next_highlight_id to #{next_highlight_id}")
+    end
+    if next_highlight
+      Rails.logger.error("before_delete hook- inside advisory lock for, updating hl: #{next_highlight.id} prev_highlight_id to #{prev_highlight_id}")
+    end
     prev_highlight&.update_attributes(next_highlight_id: next_highlight_id)
     next_highlight&.update_attributes(prev_highlight_id: prev_highlight_id)
   end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -140,12 +140,6 @@ class Highlight < ApplicationRecord
   end
 
   def reconnect_neighbors_around_destroyed_highlight
-    if prev_highlight
-      Rails.logger.error("before_delete hook- inside advisory lock for, updating hl: #{prev_highlight.id} next_highlight_id to #{next_highlight_id}")
-    end
-    if next_highlight
-      Rails.logger.error("before_delete hook- inside advisory lock for, updating hl: #{next_highlight.id} prev_highlight_id to #{prev_highlight_id}")
-    end
     prev_highlight&.update_attributes(next_highlight_id: next_highlight_id)
     next_highlight&.update_attributes(prev_highlight_id: prev_highlight_id)
   end


### PR DESCRIPTION
This resolves the Highlights deadlock and foreign key problems by adding an advisory lock mutex around the destroy action.  This allows the destroy to complete the action of repairing the prev and next ids before being deleted **in the event** that there is a concurrent destructive action on the prev and next ids.   

associated PR https://github.com/openstax/perf-testing/pull/4

![image](https://user-images.githubusercontent.com/352161/72926744-cb1e9300-3d09-11ea-99fb-caed90d962fd.png)

https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/728