### PR TITLE
Improve /info performance by adding a index to highlights

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,8 +89,9 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-end
 
+  gem 'rack-mini-profiler'
+end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,8 @@ GEM
     rack (2.0.8)
     rack-cors (1.1.0)
       rack (>= 2.0.0)
+    rack-mini-profiler (2.0.2)
+      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -286,6 +288,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.12)
   rack-cors
+  rack-mini-profiler
   rails (~> 5.2.3)
   rspec-json_expectations
   rspec-rails (~> 3.8)

--- a/db/migrate/20200622170535_add_user_id_source_id_index_to_highlights.rb
+++ b/db/migrate/20200622170535_add_user_id_source_id_index_to_highlights.rb
@@ -1,0 +1,5 @@
+class AddUserIdSourceIdIndexToHighlights < ActiveRecord::Migration[5.2]
+  def change
+    add_index :highlights, [:user_id, :source_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_135519) do
+ActiveRecord::Schema.define(version: 2020_06_22_170535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_135519) do
     t.index ["prev_highlight_id"], name: "index_highlights_on_prev_highlight_id"
     t.index ["scope_id"], name: "index_highlights_on_scope_id"
     t.index ["source_type"], name: "index_highlights_on_source_type"
+    t.index ["user_id", "source_id"], name: "index_highlights_on_user_id_and_source_id"
     t.index ["user_id"], name: "index_highlights_on_user_id"
   end
 

--- a/public/profiling.html
+++ b/public/profiling.html
@@ -1,0 +1,16 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page title</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+To use mini-profiler on a json page, run the json query first.  Then, run this page.
+This works because mini-profile caches the json query in memory, but needs a html/body page
+in order to show the results.
+
+</body>
+</html>


### PR DESCRIPTION
After using mini-profiler to find performance issues, we found one query that was doing a seq scan that could be improved significantly with an index

This is the problem query

![image](https://user-images.githubusercontent.com/352161/85320907-ad9c5380-b478-11ea-81d4-7f0e859f2912.png)

It's using a seq scan (no bueno)
```
      explain analyze SELECT
        count(*)
      FROM
        ( SELECT
            COUNT(*)
          FROM highlights
          GROUP BY user_id, source_id 
            HAVING COUNT(*) > 200) temp_table
```

the before explain plan: 
```
Aggregate  (cost=731705.50..731705.51 rows=1 width=8) (actual time=14214.049..14214.049 rows=1 loops=1)
  ->  GroupAggregate  (cost=701895.89..728663.70 rows=243344 width=61) (actual time=9065.778..14214.018 rows=128 loops=1)
        Group Key: highlights.user_id, highlights.source_id
        Filter: (count(*) > 200)
        Rows Removed by Filter: 208816
        ->  Sort  (cost=701895.89..707979.49 rows=2433437 width=53) (actual time=9021.165..13711.078 rows=2433437 loops=1)
              Sort Key: highlights.user_id, highlights.source_id
              Sort Method: external merge  Disk: 149888kB
              ->  Seq Scan on highlights  (cost=0.00..277419.37 rows=2433437 width=53) (actual time=0.019..1063.021 rows=2433437 loops=1)
Planning time: 0.172 ms
Execution time: 14221.291 ms
```

the after explain plan (when it has the index in place)
```
Aggregate  (cost=152308.13..152308.14 rows=1 width=8) (actual time=843.431..843.431 rows=1 loops=1)
  ->  GroupAggregate  (cost=0.56..149266.33 rows=243344 width=61) (actual time=9.327..843.374 rows=128 loops=1)
        Group Key: highlights.user_id, highlights.source_id
        Filter: (count(*) > 200)
        Rows Removed by Filter: 208816
        ->  Index Only Scan using index_highlights_on_user_id_and_source_id on highlights  (cost=0.56..128582.11 rows=2433437 width=53) (actual time=0.041..401.562 rows=2433437 loops=1)
              Heap Fetches: 0
Planning time: 0.238 ms
Execution time: 843.570 ms
```


I also tested the possibility of improving this (mentioned by @TomWoodward) 
![image](https://user-images.githubusercontent.com/352161/85321110-04099200-b479-11ea-81e2-c5a1c0e32b9e.png)

https://stackoverflow.com/questions/31966218/postgresql-create-an-index-to-quickly-distinguish-null-from-non-null-values

But adding a where null index did not help this seq scan for a where not null text field (annotation).  And it doesnt make sense to add a text index on where not null for just this simple count on info.   

For this query `explain analyze SELECT DISTINCT "highlights"."user_id" FROM "highlights" WHERE "highlights"."annotation" IS NOT NULL;` the plan (on the current db) is this
```HashAggregate  (cost=277812.37..277923.25 rows=11088 width=16) (actual time=902.123..904.129 rows=11288 loops=1)
  Group Key: user_id
  ->  Seq Scan on highlights  (cost=0.00..277419.37 rows=157200 width=16) (actual time=0.024..854.344 rows=161683 loops=1)
        Filter: (annotation IS NOT NULL)
        Rows Removed by Filter: 2271754
Planning time: 0.217 ms
Execution time: 905.093 ms
```
which isnt terrible.   




