### PR TITLE
allow empty annotation updates

### DIFF
--- a/app/services/service_limits.rb
+++ b/app/services/service_limits.rb
@@ -45,7 +45,7 @@ class ServiceLimits
         raise ActiveRecord::RecordInvalid.new(model) if model.invalid?
 
         track_and_validate_max_highlights(model)
-        track_and_validate_annotation_chars(model) if model.annotation.present?
+        track_and_validate_annotation_chars(model) if model.annotation.is_a?(String)
       end
     end
   end
@@ -56,7 +56,7 @@ class ServiceLimits
         raise ArgumentError, 'Block did not yield an active record model' unless model.is_a?(Highlight)
         raise ActiveRecord::RecordInvalid.new(model) if model.invalid?
 
-        track_and_validate_annotation_chars(model) if model.annotation.present?
+        track_and_validate_annotation_chars(model) if model.annotation.is_a?(String)
       end
     end
   end
@@ -118,7 +118,7 @@ class ServiceLimits
   def track_counts_for_deleted_highlight(highlight)
     user.increment_num_highlights(by: -1)
 
-    if highlight.annotation.present?
+    if highlight.annotation.is_a?(String)
       user.increment_num_annotation_characters(by: -highlight.annotation.length)
     end
 

--- a/lib/v0_bindings_extensions.rb
+++ b/lib/v0_bindings_extensions.rb
@@ -109,7 +109,7 @@ Rails.application.config.to_prepare do
   Api::V0::Bindings::HighlightUpdate.class_exec do
     def update_model!(model)
       model.color = color if color.present?
-      model.annotation = annotation if annotation.present?
+      model.annotation = annotation if annotation.is_a?(String)
       model.tap(&:save!)
     end
   end

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -486,8 +486,7 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
         end
 
         it 'can be set back to empty' do
-          put highlights_path(id: highlight.id), params: { highlight: { annotation: 'note' } }
-          expect(highlight.reload.annotation).to eq 'note'
+          expect(highlight.annotation.present?).to eq true
           put highlights_path(id: highlight.id), params: { highlight: { annotation: '' } }
           expect(highlight.reload.annotation).to eq ''
           expect(response).to have_http_status :ok

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -478,10 +478,18 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
         expect(response).to have_http_status :ok
       end
 
-      it 'can update annotation' do
-        put highlights_path(id: highlight.id), params: { highlight: { annotation: 'oh yeah' } }
-        expect(highlight.reload.annotation).to eq 'oh yeah'
-        expect(response).to have_http_status :ok
+      context 'when updating annotation' do
+        it 'updates with given string' do
+          put highlights_path(id: highlight.id), params: { highlight: { annotation: 'oh yeah' } }
+          expect(highlight.reload.annotation).to eq 'oh yeah'
+          expect(response).to have_http_status :ok
+        end
+
+        it 'can be set to empty' do
+          put highlights_path(id: highlight.id), params: { highlight: { annotation: '' } }
+          expect(highlight.reload.annotation).to eq ''
+          expect(response).to have_http_status :ok
+        end
       end
 
       context 'when the highlight does not exist' do

--- a/spec/requests/api/v0/highlights_controller_spec.rb
+++ b/spec/requests/api/v0/highlights_controller_spec.rb
@@ -485,7 +485,9 @@ RSpec.describe Api::V0::HighlightsController, type: :request do
           expect(response).to have_http_status :ok
         end
 
-        it 'can be set to empty' do
+        it 'can be set back to empty' do
+          put highlights_path(id: highlight.id), params: { highlight: { annotation: 'note' } }
+          expect(highlight.reload.annotation).to eq 'note'
           put highlights_path(id: highlight.id), params: { highlight: { annotation: '' } }
           expect(highlight.reload.annotation).to eq ''
           expect(response).to have_http_status :ok

--- a/spec/services/service_limits_spec.rb
+++ b/spec/services/service_limits_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe ServiceLimits, type: :service do
       it 'will update when annotation is set to empty string' do
         expect do
           service_limits.with_update_protection do
-            highlight.annotation = ""
+            highlight.annotation = ''
             highlight.tap(&:save!)
           end
         end.to_not raise_error
@@ -227,16 +227,14 @@ RSpec.describe ServiceLimits, type: :service do
       end
 
       it 'counts whitespace only annotations' do
-        whitespace_annotation = " \n"
-
         expect do
           service_limits.with_update_protection do
-            highlight.annotation = whitespace_annotation
+            highlight.annotation = " \n"
             highlight.tap(&:save!)
           end
         end.to_not raise_error
 
-        expect(user.reload.num_annotation_characters).to eq whitespace_annotation.length
+        expect(user.reload.num_annotation_characters).to eq 2
       end
     end
 

--- a/spec/services/service_limits_spec.rb
+++ b/spec/services/service_limits_spec.rb
@@ -209,6 +209,37 @@ RSpec.describe ServiceLimits, type: :service do
       end
     end
 
+    context 'whitespace annotations' do
+      let!(:user) { create(:new_user, num_annotation_characters: user_annotation.length ) }
+      let!(:highlight) { create(:highlight, user: user, annotation: user_annotation) }
+
+      let(:user_annotation) { 'annotation' }
+
+      it 'will update when annotation is set to empty string' do
+        expect do
+          service_limits.with_update_protection do
+            highlight.annotation = ""
+            highlight.tap(&:save!)
+          end
+        end.to_not raise_error
+
+        expect(user.reload.num_annotation_characters).to eq 0
+      end
+
+      it 'counts whitespace only annotations' do
+        whitespace_annotation = " \n"
+
+        expect do
+          service_limits.with_update_protection do
+            highlight.annotation = whitespace_annotation
+            highlight.tap(&:save!)
+          end
+        end.to_not raise_error
+
+        expect(user.reload.num_annotation_characters).to eq whitespace_annotation.length
+      end
+    end
+
     context 'limits for max chars per annotation per user' do
       let!(:user) { create(:new_user, num_annotation_characters: under_10.length) }
       let!(:highlight) { create(:highlight, user: user, annotation: under_10) }
@@ -242,19 +273,6 @@ RSpec.describe ServiceLimits, type: :service do
         end.to_not raise_error
 
         expect(user.reload.num_annotation_characters).to eq under_10.length
-      end
-
-      it 'will update when annotation is set to empty string' do
-        expect(user.num_annotation_characters).not_to eq 0
-
-        expect do
-          service_limits.with_update_protection do
-            highlight.annotation = ""
-            highlight.tap(&:save!)
-          end
-        end.to_not raise_error
-
-        expect(user.reload.num_annotation_characters).to eq 0
       end
     end
   end

--- a/spec/services/service_limits_spec.rb
+++ b/spec/services/service_limits_spec.rb
@@ -243,6 +243,19 @@ RSpec.describe ServiceLimits, type: :service do
 
         expect(user.reload.num_annotation_characters).to eq under_10.length
       end
+
+      it 'will update when annotation is set to empty string' do
+        expect(user.num_annotation_characters).not_to eq 0
+
+        expect do
+          service_limits.with_update_protection do
+            highlight.annotation = ""
+            highlight.tap(&:save!)
+          end
+        end.to_not raise_error
+
+        expect(user.reload.num_annotation_characters).to eq 0
+      end
     end
   end
 


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/758

Not sure if checking `is_a?(String)` is redundant.
Also, since this would allow whitespace only notes, if to count their characters. 