### PR TITLE
remove environment check from info response

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -28,6 +28,10 @@ class Api::V0::BaseController < ApplicationController
 
   protected
 
+  def validate_not_production
+    head :unauthorized if Utilities.production_deployment?
+  end
+
   def validate_current_user_authorized_as_admin
     head :unauthorized unless current_user_authorized_as_admin?
   end

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -33,7 +33,6 @@ class Api::V0::BaseController < ApplicationController
   end
 
   def current_user_authorized_as_admin?
-    return true unless Utilities.production_deployment?
     return false if Rails.application.secrets.admin_uuids.blank?
 
     allowed_uuids = Rails.application.secrets.admin_uuids.split(',').map(&:strip)

--- a/app/controllers/api/v0/diagnostics_controller.rb
+++ b/app/controllers/api/v0/diagnostics_controller.rb
@@ -1,5 +1,5 @@
 class Api::V0::DiagnosticsController < Api::V0::BaseController
-  before_action :validate_current_user_authorized_as_admin
+  before_action :validate_not_production
 
   # Forcing an exception
   def exception

--- a/spec/requests/api/v0/info_requests_spec.rb
+++ b/spec/requests/api/v0/info_requests_spec.rb
@@ -4,15 +4,6 @@ RSpec.describe 'api v0 info requests', type: :request, api: :v0 do
   let(:user_id) { '7307bc10-6923-4687-81df-2db0c3e6b595' }
 
   describe '#info' do
-    context 'user permitted' do
-      it 'returns info' do
-        api_get '/info'
-        expect(response).to have_http_status(:ok)
-
-        json = json_response
-        expect(json).to have_key(:postgres_version)
-      end
-    end
 
     context 'user not permitted' do
       before do


### PR DESCRIPTION
the analytics is still timing out on `prod_lite` environments, we need the option to be able to load this in sandbox somehow, this environment check was making it impossible to load it when logged out