### PR TITLE
Updated openstax_auth to enable using SSO cookies in the Authorization header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "openstax_swagger", github: 'openstax/swagger-rails', ref: '9bff4962b31e142d
 # Allow requests with a 'highlights' prefix to support use via CloudFront
 gem "openstax_path_prefixer", github: 'openstax/path_prefixer', ref: '0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd'
 
-gem "openstax_auth", github: 'openstax/auth-rails', ref: 'ed2d7da86ca226b93376955b9474c4cf115c611f'
+gem "openstax_auth"
 
 gem 'openstax_content'
 gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/openstax/auth-rails.git
-  revision: ed2d7da86ca226b93376955b9474c4cf115c611f
-  ref: ed2d7da86ca226b93376955b9474c4cf115c611f
-  specs:
-    openstax_auth (0.1.0)
-      activesupport
-      json-jwt
-
-GIT
   remote: https://github.com/openstax/path_prefixer.git
   revision: 0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd
   ref: 0ed5cdba6be65dbf1d07fd7580e2311a2f42cdfd
@@ -72,7 +63,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aes_key_wrap (1.0.1)
+    aes_key_wrap (1.1.0)
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.2.0)
@@ -94,7 +85,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    bindata (2.4.4)
+    bindata (2.4.10)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -103,7 +94,7 @@ GEM
       json
       simplecov
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.10)
     crass (1.0.5)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -122,12 +113,12 @@ GEM
     ffi (1.15.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.2)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     jmespath (1.6.1)
     json (2.3.1)
-    json-jwt (1.11.0)
+    json-jwt (1.14.0)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
@@ -151,7 +142,7 @@ GEM
       nokogiri (~> 1)
     mini_mime (1.0.2)
     mini_portile2 (2.8.0)
-    minitest (5.14.0)
+    minitest (5.16.2)
     msgpack (1.3.1)
     multipart-post (2.1.1)
     nio4r (2.5.2)
@@ -160,6 +151,8 @@ GEM
       racc (~> 1.4)
     oj (3.10.0)
     oj_mimic_json (1.0.1)
+    openstax_auth (0.2.0)
+      json-jwt
     openstax_content (1.1.0)
       aws-sdk-s3
       faraday
@@ -270,7 +263,7 @@ GEM
     swagger-blocks (3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (1.5.0)
     versionist (1.7.0)
@@ -299,7 +292,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 4.0)
   lograge
   nokogiri
-  openstax_auth!
+  openstax_auth
   openstax_content
   openstax_healthcheck
   openstax_path_prefixer!
@@ -329,4 +322,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.3.7


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1980
Note that openstax_auth is actually https://github.com/openstax/auth-ruby, not auth-rails.