### PR TITLE
Downgrade dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'openstax_healthcheck'
 # For installing secrets on deploy
 gem "aws-sdk-ssm"
 
-gem 'dotenv-rails'
+gem 'dotenv-rails', '3.1.4'
 
 gem 'will_paginate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,9 +119,9 @@ GEM
     date (3.4.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    dotenv (3.1.8)
-    dotenv-rails (3.1.8)
-      dotenv (= 3.1.8)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
       railties (>= 6.1)
     erubi (1.13.1)
     factory_bot (6.5.5)
@@ -355,7 +355,7 @@ DEPENDENCIES
   byebug
   codecov
   concurrent-ruby (= 1.3.4)
-  dotenv-rails
+  dotenv-rails (= 3.1.4)
   factory_bot_rails
   listen
   lograge


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-658

Force dotenv to 3.1.4 because 3.1.5 breaks parsing of empty exports, like `export A=`